### PR TITLE
Linux build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,19 @@ The DJI Moonlight project is made up of three parts:
 
 This is a stripped down version of [moonlight-embedded](https://github.com/moonlight-stream/moonlight-embedded) that just yeets encoded
 frames over the BULK or RNDIS to the shim.
+
+## Building
+
+### Linux - Ubuntu 22.04
+
+Pre-requisites:
+
+```
+apt install build-essential cmake libcurl4-openssl-dev libssl-dev libusb-1.0-0-dev
+git clone https://github.com/fpv-wtf/dji-moonlight-embedded.git
+cd dji-moonlight-embedded
+git submodule update --init --recursive
+cmake .
+make
+```
+

--- a/src/video/dji_usb.c
+++ b/src/video/dji_usb.c
@@ -59,13 +59,6 @@ dji_usb_setup(int videoFormat, int width, int height, int redrawRate, void *cont
         exit(1);
     }
 
-    r = libusb_set_configuration(dev, USB_CONFIG);
-    if (r != 0)
-    {
-        fprintf(stderr, "unable to set configuration: (%d) %s\n", r, libusb_strerror(r));
-        exit(1);
-    }
-
     connect_header_t header;
     header.magic = DJI_HEADER_MAGIC;
     header.width = width;


### PR DESCRIPTION
Added list of pre-reqs and instructions for building in Ubuntu 22.04

removed libusb set configuration which errors out under linux and is unneeded on windows.